### PR TITLE
Import rake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,10 @@ gem 'figaro'
 gem 'pg'
 gem 'fast_jsonapi'
 
+group :test do
+  gem 'rack-test', require: false
+end
+
 group :development, :test do
   gem 'shotgun'
   gem 'tux'
@@ -21,4 +25,5 @@ group :development, :test do
   gem 'simplecov'
   gem 'rack-test'
   gem "shoulda-matchers", "~> 2.4.0", require: false
+  gem 'colorize'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,6 +26,7 @@ GEM
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
     coderay (1.1.2)
+    colorize (0.8.1)
     concurrent-ruby (1.1.5)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
@@ -126,6 +127,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   capybara
+  colorize
   database_cleaner
   faraday
   fast_jsonapi

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,10 @@
-require "bundler"
+require 'bundler'
 require 'sinatra/activerecord'
-require "sinatra/activerecord/rake"
+require 'sinatra/activerecord/rake'
 
 task :default => :spec
 
-# require "rspec/core/rake_task"
-# RSpec::Core::RakeTask.new(:spec) do |t|
-#   t.verbose = true
-# end
+Dir.glob('./lib/tasks/*.rake').each { |r| import r }
 
 begin
   require "rspec/core/rake_task"

--- a/app/controllers/tomato_time_api.rb
+++ b/app/controllers/tomato_time_api.rb
@@ -1,5 +1,4 @@
 require 'sinatra/namespace'
-require './app/facades/question_facade'
 require './app/models/question'
 require 'json'
 require './config/environment'
@@ -18,8 +17,6 @@ class TomatoTimeApi < Sinatra::Base
     end
 
     get '/questions' do
-      input = {question_amount: 3, category: 10, difficulty: 'easy'}
-      QuestionFacade.new(input).load_questions
       questions = Question.all
 
       [:category, :difficulty, :question].each do |filter|

--- a/app/facades/question_facade.rb
+++ b/app/facades/question_facade.rb
@@ -4,14 +4,12 @@ require './app/models/question_poro'
 class QuestionFacade
 
   def initialize(input)
-    @question_amount = input[:question_amount]
+    @question_amount = input[:amount]
     @category = input[:category]
-    @difficulty = input[:difficulty]
   end
 
   def raw_data
-    triv_api =  TriviaApiService.new
-    triv_api.service(@question_amount, @category, @difficulty)
+    triv_api = TriviaApiService.get_questions(amount: @question_amount, category: @category)
   end
 
   def load_questions

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,3 +1,4 @@
+require './config/database'
 
 class Question < ActiveRecord::Base
   validates_presence_of :category, :difficulty, :question, :correct_answer, :options

--- a/app/models/question_poro.rb
+++ b/app/models/question_poro.rb
@@ -1,11 +1,25 @@
+require 'pry'
 class QuestionPoro
   attr_reader :category, :difficulty, :question, :correct_answer, :options
 
   def initialize(question_data)
     @category = question_data[:category]
     @difficulty = question_data[:difficulty]
-    @question = question_data[:question]
-    @correct_answer = question_data[:correct_answer]
-    @options = question_data[:incorrect_answers] << @correct_answer
+    @question = question_clean(question_data[:question])
+    @correct_answer = question_clean(question_data[:correct_answer])
+    incorrect_answers = question_clean(question_data[:incorrect_answers])
+    @options = incorrect_answers << @correct_answer
+  end
+
+  def question_clean(data)
+    map = {'&quot;' => '', '&#039;'=> "'", '&rsquo;'=> "'"}
+
+    if data.kind_of?(Array)
+      map.each { |k,v| data.map do |str| str.gsub!(k,v) end }
+    else
+      map.each { |k,v| data.gsub!(k,v) }
+    end
+
+    data
   end
 end

--- a/app/models/question_poro.rb
+++ b/app/models/question_poro.rb
@@ -2,10 +2,10 @@ class QuestionPoro
   attr_reader :category, :difficulty, :question, :correct_answer, :options
 
   def initialize(question_data)
-    @category = question_data['category']
-    @difficulty = question_data['difficulty']
-    @question = question_data['question']
-    @correct_answer = question_data['correct_answer']
-    @options = question_data['incorrect_answers'] << @correct_answer
+    @category = question_data[:category]
+    @difficulty = question_data[:difficulty]
+    @question = question_data[:question]
+    @correct_answer = question_data[:correct_answer]
+    @options = question_data[:incorrect_answers] << @correct_answer
   end
 end

--- a/app/services/trivia_api_service.rb
+++ b/app/services/trivia_api_service.rb
@@ -2,9 +2,16 @@ require 'faraday'
 require 'json'
 
 class TriviaApiService
-  def service(question_amount,category,difficulty)
-    response = Faraday.get("https://opentdb.com/api.php?amount=#{question_amount}&category=#{category}&difficulty=#{difficulty}&type=multiple")
-    raw_data = response.body
-    parsed_raw_data = JSON.parse(raw_data)["results"]
+  def self.get_questions(amount:, category:)
+    new.get_questions(amount, category)
+  end
+
+  def get_questions(amount, category)
+    response = Faraday.get 'https://opentdb.com/api.php/', {
+      amount: amount,
+      category: category,
+      type: 'multiple'
+    }
+    json = JSON.parse(response.body, symbolize_names: true)[:results]
   end
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -4,9 +4,20 @@ namespace :import do
   require './config/environment'
   require 'colorize'
 
-  desc "import book trivias to db"
+  desc "import genearl knowledge trivas to db"
+  task :general do
+    destroy_all('General Knowledge')
+
+    puts "Importing General Knowledge trivias from Trivia API...".yellow
+    input = {amount: 50, category: 9}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} general knowledge trivias are successfully imported".green
+  end
+
+  desc "import book trivas to db"
   task :books do
-    destroy_all_books
+    destroy_all('Entertainment: Books')
 
     puts "Importing Book trivias from Trivia API...".yellow
     input = {amount: 50, category: 10}
@@ -17,7 +28,7 @@ namespace :import do
 
   desc "import film trivias to db"
   task :film do
-    destroy_all_film
+    destroy_all('Entertainment: Film')
 
     puts "Importing Film trivias from Trivia API...".yellow
     input = {amount: 50, category: 11}
@@ -26,9 +37,20 @@ namespace :import do
     puts "#{input[:amount]} film trivias are successfully imported".green
   end
 
+  desc "import television trivias to db"
+  task :television do
+    destroy_all('Entertainment: Television')
+
+    puts "Importing Television trivias from Trivia API...".yellow
+    input = {amount: 50, category: 14}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} television trivias are successfully imported".green
+  end
+
   desc "import music trivias to db"
   task :music do
-    destroy_all_music
+    destroy_all('Entertainment: Music')
 
     puts "Importing Music trivias from Trivia API...".yellow
     input = {amount: 50, category: 12}
@@ -37,20 +59,31 @@ namespace :import do
     puts "#{input[:amount]} music trivias are successfully imported".green
   end
 
-  desc "import computer trivias to db"
-  task :computer do
-    destroy_all_computer
+  desc "import science and nature trivias to db"
+  task :science_nature do
+    destroy_all('Science & Nature')
 
-    puts "Importing Computer trivias from Trivia API...".yellow
-    input = {amount: 50, category: 18}
+    puts "Importing Science & Nature trivias from Trivia API...".yellow
+    input = {amount: 50, category: 17}
     QuestionFacade.new(input).load_questions
 
-    puts "#{input[:amount]} computer trivias are successfully imported".green
+    puts "#{input[:amount]} science and nature trivias are successfully imported".green
+  end
+
+  desc "import geography trivias to db"
+  task :geography do
+    destroy_all('Geography')
+
+    puts "Importing Geography trivias from Trivia API...".yellow
+    input = {amount: 50, category: 22}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} geography trivias are successfully imported".green
   end
 
   desc "import history trivias to db"
   task :history do
-    destroy_all_history
+    destroy_all('History')
 
     puts "Importing History trivias from Trivia API...".yellow
     input = {amount: 50, category: 23}
@@ -59,37 +92,22 @@ namespace :import do
     puts "#{input[:amount]} history trivias are successfully imported".green
   end
 
-  task all: [:books, :film, :music, :computer, :history]
+  task all: [:general, :books, :film, :television, :music, :science_nature, :geography, :history]
+end
+
+desc "clear db"
+task :destroy do
+  cleanup
 end
 
 private
 
-def destroy_all_books
-  puts "Destroying all book trivias...".yellow
-  Question.where("category = 'Entertainment: Books'").destroy_all
+def destroy_all(category)
+  puts "Destroying all #{category} trivias...".yellow
+  Question.where(category: "#{category}").destroy_all
   puts "done".green
 end
 
-def destroy_all_film
-  puts "Destroying all film trivias...".yellow
-  Question.where("category = 'Entertainment: Film'").destroy_all
-  puts "done".green
-end
-
-def destroy_all_music
-  puts "Destroying all music trivias...".yellow
-  Question.where("category = 'Entertainment: Music'").destroy_all
-  puts "done".green
-end
-
-def destroy_all_computer
-  puts "Destroying all computer trivias...".yellow
-  Question.where("category = 'Science: Computers'").destroy_all
-  puts "done".green
-end
-
-def destroy_all_history
-  puts "Destroying all history trivias...".yellow
-  Question.where("category = 'History'").destroy_all
-  puts "done".green
+def cleanup
+  Question.destroy_all
 end

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,95 @@
+namespace :import do
+  require 'bundler'
+  Bundler.require
+  require './config/environment'
+  require 'colorize'
+
+  desc "import book trivias to db"
+  task :books do
+    destroy_all_books
+
+    puts "Importing Book trivias from Trivia API...".yellow
+    input = {amount: 50, category: 10}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} book trivias are successfully imported".green
+  end
+
+  desc "import film trivias to db"
+  task :film do
+    destroy_all_film
+
+    puts "Importing Film trivias from Trivia API...".yellow
+    input = {amount: 50, category: 11}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} film trivias are successfully imported".green
+  end
+
+  desc "import music trivias to db"
+  task :music do
+    destroy_all_music
+
+    puts "Importing Music trivias from Trivia API...".yellow
+    input = {amount: 50, category: 12}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} music trivias are successfully imported".green
+  end
+
+  desc "import computer trivias to db"
+  task :computer do
+    destroy_all_computer
+
+    puts "Importing Computer trivias from Trivia API...".yellow
+    input = {amount: 50, category: 18}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} computer trivias are successfully imported".green
+  end
+
+  desc "import history trivias to db"
+  task :history do
+    destroy_all_history
+
+    puts "Importing History trivias from Trivia API...".yellow
+    input = {amount: 50, category: 23}
+    QuestionFacade.new(input).load_questions
+
+    puts "#{input[:amount]} history trivias are successfully imported".green
+  end
+
+  task all: [:books, :film, :music, :computer, :history]
+end
+
+private
+
+def destroy_all_books
+  puts "Destroying all book trivias...".yellow
+  Question.where("category = 'Entertainment: Books'").destroy_all
+  puts "done".green
+end
+
+def destroy_all_film
+  puts "Destroying all film trivias...".yellow
+  Question.where("category = 'Entertainment: Film'").destroy_all
+  puts "done".green
+end
+
+def destroy_all_music
+  puts "Destroying all music trivias...".yellow
+  Question.where("category = 'Entertainment: Music'").destroy_all
+  puts "done".green
+end
+
+def destroy_all_computer
+  puts "Destroying all computer trivias...".yellow
+  Question.where("category = 'Science: Computers'").destroy_all
+  puts "done".green
+end
+
+def destroy_all_history
+  puts "Destroying all history trivias...".yellow
+  Question.where("category = 'History'").destroy_all
+  puts "done".green
+end


### PR DESCRIPTION
This PR includes the following changes:
- Add a rake import task to load the db with `Question` objects (which are created upon API calls)
- `import.rake` file uses namespace to group related tasks (loading data by category) and displays details about its progress in the terminal output
- Refactor TriviaApiService and QuestionFacade